### PR TITLE
clean llmclient when fail to create client

### DIFF
--- a/src/api/llm.ts
+++ b/src/api/llm.ts
@@ -75,6 +75,7 @@ const createLlmClient = async (configuration: LlmConfiguration) => {
             llmClient = new OpenAIClient(configuration);
             break;
         default:
+            llmClient = null;
             throw new Error(`Unsupported LLM provider: ${configuration.provider}`);
     }
 
@@ -83,10 +84,12 @@ const createLlmClient = async (configuration: LlmConfiguration) => {
         const models = await llmClient.getModels();
         
         if (!models || models.length === 0) {
-            throw new Error(`No models found for ${llmClient.getProvider()}`);
+            llmClient = null;
+            throw new Error(`No models found for ${configuration.provider}`);
         }
     } catch (error: any) {
         // Handle API errors gracefully
+        llmClient = null;
         throw new Error(`Failed to fetch models: ${error.message}`);
     }
 };


### PR DESCRIPTION
This pull request refines error handling in the `createLlmClient` function within `src/api/llm.ts`. The changes ensure that the `llmClient` is explicitly set to `null` in cases where errors occur, improving the robustness of the function.

### Error handling improvements:
* Explicitly set `llmClient` to `null` when encountering an unsupported LLM provider to ensure proper cleanup.
* Updated error handling when no models are found or when fetching models fails, setting `llmClient` to `null` before throwing an error. This prevents potential misuse of an invalid client.