### PR TITLE
add api to get cached model

### DIFF
--- a/src/api/llm.ts
+++ b/src/api/llm.ts
@@ -117,6 +117,13 @@ const getModels = async (): Promise<string[]> => {
     return await llmClient.getModels();
 };
 
+const getModel = (): string | null => {
+    if (!llmClient) {
+        throw new Error("LLM client not initialized. Call createLlmClient first.");
+    }
+    return llmClient.getModel();
+}
+
 const setModel = async (model: string): Promise<void> => {
     if (!llmClient) {
         throw new Error("LLM client not initialized. Call createLlmClient first.");
@@ -141,6 +148,7 @@ export {
     createLlmClient,
     clearLlmClient,
     getModels,
+    getModel,
     setModel,
     // createCompletion
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
     createLlmClient,
     clearLlmClient,
     getModels,
+    getModel,
     setModel,
     // createCompletion
 } from '@/api/llm';
@@ -28,6 +29,7 @@ export {
     createLlmClient,
     clearLlmClient,
     getModels,
+    getModel,
     setModel,
     // createCompletion
 };


### PR DESCRIPTION
This pull request introduces a new function, `getModel`, to retrieve the currently selected model from the LLM client. It also ensures this function is exported and available for use in other parts of the application. Below are the key changes:

### Addition of the `getModel` function:
* [`src/api/llm.ts`](diffhunk://#diff-258a084ee1bb02480b63e3678f3dcbc0e9af63fbed694215316212402ffce0bbR120-R126): Added a new `getModel` function to retrieve the current model from the LLM client. The function throws an error if the client has not been initialized.

### Updates to exports:
* [`src/api/llm.ts`](diffhunk://#diff-258a084ee1bb02480b63e3678f3dcbc0e9af63fbed694215316212402ffce0bbR151): Exported the newly added `getModel` function.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R15): Imported and re-exported the `getModel` function to make it accessible from the module's main entry point. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R15) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R32)