### PR TITLE
clean out unneeded tests

### DIFF
--- a/src/__tests__/add.test.ts
+++ b/src/__tests__/add.test.ts
@@ -1,5 +1,0 @@
-import { add } from '../add';
-
-test('add', () => {
-  expect(add(1, 2)).toBe(3);
-});

--- a/src/__tests__/dummy.test.ts
+++ b/src/__tests__/dummy.test.ts
@@ -1,0 +1,3 @@
+test('dummy', () => {
+  expect(3).toBe(3);
+});

--- a/src/__tests__/subtract.test.ts
+++ b/src/__tests__/subtract.test.ts
@@ -1,5 +1,0 @@
-import { subtract } from '../subtract';
-
-test('subtract', () => {
-  expect(subtract(3, 2)).toBe(1);
-});

--- a/src/add.ts
+++ b/src/add.ts
@@ -1,3 +1,0 @@
-export function add(a: number, b: number): number {
-  return a + b;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { add } from './add';
-import { subtract } from './subtract';
 import {
     LlmProvider,
     OllamaConfiguration,
@@ -18,8 +16,6 @@ import {
 } from '@/api/llm';
 
 export { 
-    add, 
-    subtract,
     LlmProvider,
     OllamaConfiguration,
     OpenAIConfiguration,

--- a/src/subtract.ts
+++ b/src/subtract.ts
@@ -1,3 +1,0 @@
-export function subtract(a: number, b: number): number {
-  return a - b;
-}


### PR DESCRIPTION
This pull request removes the `add` and `subtract` utility functions and their associated test cases, as well as cleans up related imports in the codebase. Additionally, a placeholder test case (`dummy.test.ts`) has been added.

### Removal of `add` and `subtract` functionality:

* [`src/add.ts`](diffhunk://#diff-8626847e13bfbfddb683ed86873a81e97c0c46de6ee50f4dcdc78924ee133c65L1-L3): Deleted the `add` function, which performed addition of two numbers.
* [`src/subtract.ts`](diffhunk://#diff-c254f0c4eca7efa74a13e0a0da1c522e69ac609baf268ad0370e5f55b621584bL1-L3): Deleted the `subtract` function, which performed subtraction of two numbers.
* [`src/__tests__/add.test.ts`](diffhunk://#diff-bfbf606efd382a41f02d220f62c9e40882ae0797dc653e98da2bb9a9c2ed3d91L1-L5): Removed the test case for the `add` function.
* [`src/__tests__/subtract.test.ts`](diffhunk://#diff-f09fed94e6a07837620b3b400e5e6055fd54f591c5aede3a20c389adbe78534dL1-L5): Removed the test case for the `subtract` function.

### Codebase cleanup:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-L2): Removed imports and exports for the `add` and `subtract` functions. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-L2) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L21-L22)

### Addition of placeholder test:

* [`src/__tests__/dummy.test.ts`](diffhunk://#diff-e237793a5cb4a69758a0178d6cf81d3e06d302887c578231e2a0bc2beb60baa2R1-R3): Added a placeholder test case that asserts `3` is equal to `3`.