### PR TITLE
stub for image api, not released

### DIFF
--- a/src/client/openai_client.ts
+++ b/src/client/openai_client.ts
@@ -96,6 +96,11 @@ class OpenAIClient implements LlmClient {
         }
     }
 
+    /**
+     * 
+     * Not tested and released 
+     * 
+     */
     async generateImage(request: GenerateImageRequest): Promise<ImageResponse> {
         if (!request.model) {
             throw new Error("Model not set. Call setModel first.");
@@ -121,7 +126,7 @@ class OpenAIClient implements LlmClient {
             throw error;
         }
     };
-    
+
 }
 
 export default OpenAIClient;

--- a/src/client/openai_client.ts
+++ b/src/client/openai_client.ts
@@ -7,6 +7,8 @@ import {
 import { Model, Models } from "@/models/response/models";
 import { ChatRequest } from "@/models/request/chat_request";
 import { ChatCompletion } from "@/models/response/chat_completion";
+import { GenerateImageRequest } from "@/models/request/generate_image_request";
+import { ImageResponse } from "@/models/response/image_response";
 
 class OpenAIClient implements LlmClient {
     private model: Model | null = null;
@@ -93,6 +95,33 @@ class OpenAIClient implements LlmClient {
             throw error;
         }
     }
+
+    async generateImage(request: GenerateImageRequest): Promise<ImageResponse> {
+        if (!request.model) {
+            throw new Error("Model not set. Call setModel first.");
+        }
+        try {
+            const response = await fetch(`${this.baseUrl}/v1/images/generations`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${this.apiKey}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(request)
+            });
+            
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            
+            const data = await response.json();
+            return data as ImageResponse;
+        } catch (error) {
+            console.error('Error generating image:', error);
+            throw error;
+        }
+    };
+    
 }
 
 export default OpenAIClient;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -107,6 +107,45 @@ enum FinishReason {
     FUNCTION_CALL = 'function_call'
 };
 
+enum ImageSize {
+    SIZE_1024x1024 = '1024x1024',
+    SIZE_512x512 = '512x512',
+    SIZE_1024x1536 = '1024x1536',
+    SIZE_256x256 = '256x256',
+    SIZE_1792x1024 = '1792x1024',
+    SIZE_1024x1792 = '1024x1792'
+};
+
+enum ImageBackground {
+    TRANSPARANT = 'transparent',
+    OPAQUE = 'opaque',
+    AUTO = 'auto'
+};
+
+enum ImageModeration {
+    LOW = 'low',
+    AUTO = 'auto'
+};
+
+enum ImageQuality {
+    AUTO = 'auto',
+    HIGH = 'high',
+    MEDIUM = 'medium',
+    LOW = 'low',
+    HD = 'hd',
+    STANDARD = 'standard'
+};
+
+enum ImageFormat {
+    URL = 'url',
+    B64_JSON = 'b64_json'
+};
+
+enum ImageStyle {
+    VIVID = 'vivid',
+    NATURAL = 'natural'
+};
+
 export {
     Role,
     ReasoningEffort,
@@ -122,5 +161,11 @@ export {
     CompoundOperator,
     SearchContextSize,
     ResponseObject,
-    FinishReason
+    FinishReason,
+    ImageSize,
+    ImageBackground,
+    ImageModeration,
+    ImageQuality,
+    ImageFormat,
+    ImageStyle
 };

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -117,7 +117,7 @@ enum ImageSize {
 };
 
 enum ImageBackground {
-    TRANSPARANT = 'transparent',
+    TRANSPARENT = 'transparent',
     OPAQUE = 'opaque',
     AUTO = 'auto'
 };

--- a/src/models/request/generate_image_request.ts
+++ b/src/models/request/generate_image_request.ts
@@ -1,0 +1,26 @@
+import { 
+    ImageSize,
+    ImageBackground,
+    ImageModeration,
+    ImageQuality,
+    ImageFormat,
+    ImageStyle
+} from "@/models/enums";
+
+interface GenerateImageRequest {
+    model?: string | null;
+    prompt: string;
+    n?: number | null;
+    size?: ImageSize | null;
+    background?: ImageBackground | null;
+    moderation?: ImageModeration | null;
+    output_compression?: number | null;
+    quality?: ImageQuality | null;
+    response_format?: ImageFormat | null;
+    style?: ImageStyle | null;
+    user?: string | null;
+};
+
+export {
+    GenerateImageRequest
+};

--- a/src/models/response/image_response.ts
+++ b/src/models/response/image_response.ts
@@ -1,0 +1,18 @@
+import { ImageUsage } from '@/models/response/usage';
+
+interface ImageResponse {
+    created: number;
+    data?: Array<Image>;
+    usage?: ImageUsage;
+}
+
+interface Image {
+    url?: string;
+    b64_json?: string;
+    revised_prompt?: string;
+};
+
+export {
+    ImageResponse,
+    Image,
+};


### PR DESCRIPTION
This pull request introduces functionality for generating images using the OpenAI API. It includes updates to the `OpenAIClient` class, new enums for image-related attributes, and new request and response models to support the image generation feature.

### New Image Generation Feature:

* **Added `generateImage` method in `OpenAIClient`:** This method allows the client to send a request to the OpenAI API to generate images based on the provided parameters. It includes error handling for missing models and unsuccessful API responses.
* **New enums for image attributes:** Introduced enums in `src/models/enums.ts` to define image-related properties such as size, background, moderation level, quality, format, and style. These enums provide a structured way to specify image generation parameters. [[1]](diffhunk://#diff-575541f3d947cb60d8bbc7fde50ee778781113b7383ecd87b87dab813713d632R110-R148) [[2]](diffhunk://#diff-575541f3d947cb60d8bbc7fde50ee778781113b7383ecd87b87dab813713d632L125-R170)

### Request and Response Models:

* **`GenerateImageRequest` interface:** Added in `src/models/request/generate_image_request.ts`, this interface defines the structure for image generation requests, including properties like `prompt`, `size`, `quality`, and `style`.
* **`ImageResponse` interface:** Added in `src/models/response/image_response.ts`, this interface defines the structure for the API's response to an image generation request, including the generated image data and usage information.