### PR TITLE
add Streaming feature for node and react native

### DIFF
--- a/src/__tests__/integration/ollama_client.test.ts
+++ b/src/__tests__/integration/ollama_client.test.ts
@@ -1,7 +1,9 @@
 import { LlmClient } from '@/client/llm_client';
 import OpenAIClient from '@/client/openai_client';
 import { LlmProvider, OllamaConfiguration } from '@/configuration/llm_configurations';
+import { chatCompletion } from '@/index';
 import { Role, ResponseObject } from '@/models/enums';
+import { ChatCompletion, CompletionMessage, CompletionChunk } from '@/models/response/chat_completion';
 import { Model } from '@/models/response/models';
 
 const initializeClient = (): LlmClient => {
@@ -97,7 +99,7 @@ const createCompletionTest = async (client: LlmClient) => {
     });
     
     console.log('Response:', response);
-    console.log('Message ', response.choices[0].message);
+    console.log('Message ', (response.choices[0] as CompletionMessage).message);
 
     console.log('Completion test completed successfully!');
   } catch (error) {
@@ -106,9 +108,52 @@ const createCompletionTest = async (client: LlmClient) => {
   }
 }
 
+const createCompletionStreamingTest = async (client: LlmClient) => {
+  console.log('Creating completion streaming test...');
+  const listener = (completions: Array<ChatCompletion>) => {
+    let streamedResponse = '';
+    completions.forEach((completion) => {
+      if (completion.choices && completion.choices.length > 0) {
+        streamedResponse += (completion.choices[0] as CompletionChunk).delta.content;
+      }
+    });
+    console.log('Streamed response:', streamedResponse);
+  };
+  try {    
+    const response = await client.createCompletion({
+      model: "qwen3:8b",
+      messages: [
+        {
+          role: Role.USER,
+          content: 'Hello, how are you today?'
+        }
+      ],
+      stream: true,
+    }, listener);
+  
+    console.log("chatCompletionStreaming test completed successfully!");
+  } catch (error) {
+    console.error('Completion test failed:', error);
+    process.exit(1);
+  }
+}
+
 // Wrap in an immediately invoked async function to use await
-const client = initializeClient();
-getProviderTest(client);
-getModelsTest(client);
-getModelTest(client);
-createCompletionTest(client);
+(async function main() {
+  try {
+      // sync test
+      const client = initializeClient();
+
+      // promise tests in order
+      await getProviderTest(client);
+      await getModelsTest(client);
+      await getModelTest(client);
+      await createCompletionTest(client);
+      await createCompletionStreamingTest(client);
+
+      console.log("🎉 All integration tests passed");
+  } catch (err) {
+      console.error("❌ Integration tests failed:", err);
+      process.exit(1);
+  }
+})();

--- a/src/api/llm.ts
+++ b/src/api/llm.ts
@@ -12,6 +12,8 @@ import { ChatRequest } from "@/models/request/chat_request";
 import { GenerateImageRequest } from "@/models/request/generate_image_request";
 import { ImageResponse } from "@/models/response/image_response";
 
+type FetchImplementation = typeof fetch;
+
 let llmClient: LlmClient | null = null;
 
 /**
@@ -195,6 +197,27 @@ const createCompletion = async (request: ChatRequest, chatListener?: (completion
     return llmClient.createCompletion(request, chatListener);
 };
 
+const reactNativeStreamingCompletion = async (
+    request: ChatRequest,
+    customFetch: FetchImplementation,
+    chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion> => {
+
+    if (!llmClient) {
+        throw new Error("LLM client not initialized. Call createLlmClient first.");
+    }
+
+    // If the caller didn't supply a model, use the one already set in the client
+    if (!request.model) {
+        const current = getModel();
+        if (!current) {
+        throw new Error("No model set. Please set the model before calling createCompletion.");
+        }
+        request.model = current.id;
+    }
+
+    return llmClient.reactNativeStreamingCompletion(request, customFetch, chatListener);
+};
+
 /**
  * Generates an image based on the provided request.
  * Note: This method currently supports only the OPENAI provider.
@@ -227,5 +250,6 @@ export {
     getModel,
     setModel,
     createCompletion,
+    reactNativeStreamingCompletion,
     generateImage
 };

--- a/src/api/llm.ts
+++ b/src/api/llm.ts
@@ -178,7 +178,7 @@ const setModel = async (model: Model): Promise<void> => {
 };
 
 
-const createCompletion = async (request: ChatRequest): Promise<ChatCompletion> => {
+const createCompletion = async (request: ChatRequest, chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion> => {
     if (!llmClient) {
         throw new Error("LLM client not initialized. Call createLlmClient first.");
     }
@@ -192,7 +192,7 @@ const createCompletion = async (request: ChatRequest): Promise<ChatCompletion> =
         request.model = current.id;
     }
 
-    return llmClient.createCompletion(request);
+    return llmClient.createCompletion(request, chatListener);
 };
 
 /**

--- a/src/client/llm_client.ts
+++ b/src/client/llm_client.ts
@@ -11,6 +11,6 @@ export interface LlmClient {
     getModels(): Promise<Models>;
     getModel(): Model | null;
     setModel(model: Model): void;
-    createCompletion(request: ChatRequest): Promise<ChatCompletion>;
+    createCompletion(request: ChatRequest, chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion>;
     generateImage(request: GenerateImageRequest): Promise<ImageResponse>;
 }

--- a/src/client/llm_client.ts
+++ b/src/client/llm_client.ts
@@ -5,12 +5,20 @@ import { ChatCompletion } from "@/models/response/chat_completion";
 import { GenerateImageRequest } from "@/models/request/generate_image_request";
 import { ImageResponse } from "@/models/response/image_response";
 
+type FetchImplementation = typeof fetch;
+
 export interface LlmClient {
     getProvider(): LlmProvider;
     getCachedModels(): Model[] | null;
     getModels(): Promise<Models>;
     getModel(): Model | null;
     setModel(model: Model): void;
-    createCompletion(request: ChatRequest, chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion>;
+    createCompletion(
+        request: ChatRequest, 
+        chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion>;
+    reactNativeStreamingCompletion(
+        request: ChatRequest, 
+        customFetch: FetchImplementation,
+        chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion>;
     generateImage(request: GenerateImageRequest): Promise<ImageResponse>;
 }

--- a/src/client/openai_client.ts
+++ b/src/client/openai_client.ts
@@ -4,18 +4,20 @@ import {
     OpenAIConfiguration,
     LlmProvider
 } from "@/configuration/llm_configurations";
+import { sseDecoder } from "@/utils/decoder";
 import { Model, Models } from "@/models/response/models";
 import { ChatRequest } from "@/models/request/chat_request";
 import { ChatCompletion } from "@/models/response/chat_completion";
 import { GenerateImageRequest } from "@/models/request/generate_image_request";
 import { ImageResponse } from "@/models/response/image_response";
+import { ServerSentEvent } from "@/models/server_sent_event";
 
 class OpenAIClient implements LlmClient {
     private model: Model | null = null;
     private models: Model[] | null = null;
     private provider: LlmProvider;
-    private apiKey: string;
-    private baseUrl: string = 'https://api.openai.com';
+    protected apiKey: string;
+    protected baseUrl: string = 'https://api.openai.com';
 
     constructor( 
         configuration: OllamaConfiguration | OpenAIConfiguration,
@@ -69,8 +71,16 @@ class OpenAIClient implements LlmClient {
     setModel(model: Model): void {  
         this.model = model;
     }
+    
+    async createCompletion(request: ChatRequest, chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion> {
+        if (request.stream) {
+            return this.createCompletionStreaming(request, chatListener);
+        } else {
+            return this.createCompletionNonStreaming(request);
+        }
+    }
 
-    async createCompletion(request: ChatRequest): Promise<ChatCompletion> {
+    async createCompletionNonStreaming(request: ChatRequest): Promise<ChatCompletion> {
         try {
             const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
                 method: 'POST',
@@ -90,6 +100,46 @@ class OpenAIClient implements LlmClient {
             return data as ChatCompletion;
         } catch (error) {
             console.error('Error creating completion:', error);
+            throw error;
+        }
+    }
+
+    async createCompletionStreaming(request: ChatRequest, chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion> {
+        try {
+            const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${this.apiKey}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(request)
+            });
+
+            if (!response.ok) {
+                const errJson = await response.json();
+                throw new Error(`HTTP error! status: ${errJson.error.message}`);
+            }
+
+            const body = response.body as ReadableStream<Uint8Array>;
+            const reader = body.getReader();
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+        
+                let chunk = new TextDecoder().decode(value);
+                const sses: Array<ServerSentEvent> = sseDecoder(chunk);
+
+                const completions = sses
+                    .filter(sse => !sse.finished)
+                    .map(sse => JSON.parse(sse.data) as ChatCompletion);
+                if (chatListener && completions.length > 0) {
+                    chatListener(completions);
+                }
+            }
+            return {} as ChatCompletion; // Return an empty object or handle the completion as needed 
+        } catch (error) {
+            console.error('Error streaming completion:', error);
             throw error;
         }
     }

--- a/src/client/openai_client.ts
+++ b/src/client/openai_client.ts
@@ -12,6 +12,8 @@ import { GenerateImageRequest } from "@/models/request/generate_image_request";
 import { ImageResponse } from "@/models/response/image_response";
 import { ServerSentEvent } from "@/models/server_sent_event";
 
+type FetchImplementation = typeof fetch;
+
 class OpenAIClient implements LlmClient {
     private model: Model | null = null;
     private models: Model[] | null = null;
@@ -104,7 +106,9 @@ class OpenAIClient implements LlmClient {
         }
     }
 
-    async createCompletionStreaming(request: ChatRequest, chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion> {
+    async createCompletionStreaming(
+        request: ChatRequest, 
+        chatListener?: (completions: Array<ChatCompletion>) => void): Promise<ChatCompletion> {
         try {
             const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
                 method: 'POST',
@@ -143,6 +147,51 @@ class OpenAIClient implements LlmClient {
             throw error;
         }
     }
+
+    async reactNativeStreamingCompletion(
+        request: ChatRequest, 
+        customFetch: FetchImplementation,
+        chatListener?: (completions: Array<ChatCompletion>) => void    
+    ): Promise<ChatCompletion> {
+        try {
+            const response = await customFetch(`${this.baseUrl}/v1/chat/completions`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${this.apiKey}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(request)
+            });
+
+            if (!response.ok) {
+                const errJson = await response.json();
+                throw new Error(`HTTP error! status: ${errJson.error.message}`);
+            }
+
+            const body = response.body as ReadableStream<Uint8Array>;
+            const reader = body.getReader();
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+        
+                let chunk = new TextDecoder().decode(value);
+                const sses: Array<ServerSentEvent> = sseDecoder(chunk);
+
+                const completions = sses
+                    .filter(sse => !sse.finished)
+                    .map(sse => JSON.parse(sse.data) as ChatCompletion);
+                if (chatListener && completions.length > 0) {
+                    chatListener(completions);
+                }
+            }
+            return {} as ChatCompletion; // Return an empty object or handle the completion as needed 
+        } catch (error) {
+            console.error('Error streaming completion:', error);
+            throw error;
+        }
+    }
+
 
    /**
      * Generates an image based on the provided request.

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -97,7 +97,8 @@ enum ResponseObject {
     LIST = 'list',
     MODEL = 'model',
     COMPLETION = 'completion',
-    FUNCTION='function'
+    FUNCTION='function',
+    CHAT_COMPLETION_CHUNK = 'chat.completion.chunk'
 };
 
 enum FinishReason {

--- a/src/models/response/chat_completion.ts
+++ b/src/models/response/chat_completion.ts
@@ -9,23 +9,36 @@ import { Usage } from "@/models/response/usage";
 
 interface ChatCompletion {
     id: string;
-    object: ResponseObject.COMPLETION;
+    object: ResponseObject.COMPLETION | ResponseObject.CHAT_COMPLETION_CHUNK;
     created: number;
     model: string;
     system_fingerprint?: string;
-    choices: Array<Choice>;
+    choices: Array<CompletionChoice>;
     usage: Usage;
     service_teir?: ServiceTeir | null;
 };
 
-interface Choice {
+type CompletionChoice = 
+    | CompletionMessage
+    | CompletionChunk;
+
+interface CompletionMessage {
     index: number;
     message: Message;
     finished_reason: FinishReason; 
     logprobs?: LogProbs | null;
 };
 
+interface CompletionChunk {
+    index: number;
+    delta: Message;
+    finished_reason: FinishReason; 
+    logprobs?: LogProbs | null;
+};
+
 export {
     ChatCompletion,
-    Choice
+    CompletionChoice,
+    CompletionMessage,
+    CompletionChunk
 };

--- a/src/models/server_sent_event.ts
+++ b/src/models/server_sent_event.ts
@@ -1,0 +1,10 @@
+interface ServerSentEvent {
+    id?: string;
+    data: string;
+    event?: string;
+    finished?: boolean;
+};
+
+export {
+    ServerSentEvent
+};

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -1,0 +1,23 @@
+import { ServerSentEvent } from "@/models/server_sent_event"
+
+const sseDecoder = (stream: string): Array<ServerSentEvent> => {
+    const lines = stream.split("\n");
+    const events: Array<ServerSentEvent> = [];
+    if (!stream.trim()) return events;
+
+    for (const line of lines) {
+        if (line.startsWith("data:")) {
+            const data = line.substring(5).trim();
+            events.push({ 
+                data: data,
+                finished: data === "[DONE]",
+            } as ServerSentEvent);
+        }
+    }
+
+    return events;
+};
+
+export {
+    sseDecoder,
+};


### PR DESCRIPTION
This pull request introduces support for streaming chat completions in the LLM API, along with corresponding updates to the client, models, and integration tests. The most significant changes include adding streaming functionality to the `createCompletion` method, introducing a new `reactNativeStreamingCompletion` method, and updating the data models to handle streaming responses.

To stream in your react native expo app you need to pass expo fetch api into our reactNativeStreamingCompletion api.
```
import { fetch } from 'expo/fetch';
import { api, chatCompletion } from "@innobridge/llmclient";

const { reactNativeStreamingCompletion } = api;

const listener = (completions: Array<chatCompletion.ChatCompletion>) => {
    // does something with completions
}

await reactNativeStreamingCompletion(chatRequest, fetch as unknown as typeof globalThis.fetch, listener);
```

### Streaming Functionality Enhancements:

* [`src/api/llm.ts`](diffhunk://#diff-258a084ee1bb02480b63e3678f3dcbc0e9af63fbed694215316212402ffce0bbL195-R218): Updated the `createCompletion` method to support a `chatListener` callback for handling streaming responses. Added a new `reactNativeStreamingCompletion` method for React Native environments, which uses a custom fetch implementation. (F5db8e34L178R215, [src/api/llm.tsL195-R218](diffhunk://#diff-258a084ee1bb02480b63e3678f3dcbc0e9af63fbed694215316212402ffce0bbL195-R218))
* [`src/client/openai_client.ts`](diffhunk://#diff-e7a6c3019c305782ac82442e319d771548654b673895427e0c3a06812aa4cbbeL73-R85): Implemented `createCompletionStreaming` and `reactNativeStreamingCompletion` methods in the `OpenAIClient` class to handle streaming responses using server-sent events (SSE). [[1]](diffhunk://#diff-e7a6c3019c305782ac82442e319d771548654b673895427e0c3a06812aa4cbbeL73-R85) [[2]](diffhunk://#diff-e7a6c3019c305782ac82442e319d771548654b673895427e0c3a06812aa4cbbeR109-R195)

### Model Updates:

* [`src/models/response/chat_completion.ts`](diffhunk://#diff-01b390716a0a2c920f4537b6e186c1a47b580dd686cb4df85b24a155f2638af5L12-R43): Updated the `ChatCompletion` interface to support both standard and streaming responses by introducing `CompletionMessage` and `CompletionChunk` types.
* [`src/models/server_sent_event.ts`](diffhunk://#diff-90917445df717a683593ad0a9f66e4c2f677e19a7469b3c0dd20f11699e7bfebR1-R10): Added a new `ServerSentEvent` interface to represent SSE data.

### Utility Additions:

* [`src/utils/decoder.ts`](diffhunk://#diff-ccc5937ef907331c1c102f3aa494985ded5527e880ec16d81e27b2bb09b45121R1-R23): Added a new `sseDecoder` utility function to parse SSE data streams into structured events.

### Integration Tests:

* `src/__tests__/integration/llm_api.test.ts` and `src/__tests__/integration/ollama_client.test.ts`: Added new test cases (`createCompletionStreamTest` and `createCompletionStreamingTest`) to validate the streaming functionality. Updated existing tests to handle the new `CompletionMessage` type. [[1]](diffhunk://#diff-ef6851150c256c2ee0c301d229d62f5676008f68625d9da15f39e5bc94aded31R204-R235) [[2]](diffhunk://#diff-2bbad5ac3126a9a70151ae0c2b20739ceb64d03f3c8146b7c47eca197155fce6R111-R159)

These changes collectively enhance the LLM API's capabilities to support real-time streaming responses, improving its flexibility and usability in various environments.