### PR TITLE
make data in image response not optional

### DIFF
--- a/src/models/response/image_response.ts
+++ b/src/models/response/image_response.ts
@@ -2,7 +2,7 @@ import { ImageUsage } from '@/models/response/usage';
 
 interface ImageResponse {
     created: number;
-    data?: Array<Image>;
+    data: Array<Image>;
     usage?: ImageUsage;
 }
 


### PR DESCRIPTION
This pull request includes a small but significant change to the `ImageResponse` interface in `src/models/response/image_response.ts`. The `data` property has been updated to be a required field instead of an optional one, ensuring that any `ImageResponse` object must include an array of `Image` objects.