### PR TITLE
no role name bots in openai

### DIFF
--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -4,7 +4,7 @@ enum Role {
     USER = 'user',
     ASSISTANT = 'assistant',
     TOOL = 'tool',
-    BOT = 'bot',
+    FUNCTION = 'function'
 };
 
 enum ReasoningEffort {

--- a/src/models/request/message.ts
+++ b/src/models/request/message.ts
@@ -12,7 +12,7 @@ type Message =
     | UserMessage 
     | AssistantMessage 
     | ToolMessage
-    | BotMessage;
+    | FunctionMessage;
 
 interface DeveloperMessage {
     content: string | Array<TextContent>;
@@ -46,8 +46,8 @@ interface ToolMessage {
     tool_call_id: string;
 };
 
-interface BotMessage {
-    role: Role.BOT;
+interface FunctionMessage {
+    role: Role.FUNCTION;
     content: string | Array<TextContent>;
     name?: string;
 };


### PR DESCRIPTION
This pull request updates the naming conventions in the codebase to replace references to "Bot" with "Function" for improved clarity and alignment with the application's domain model. The most important changes include renaming the `Role.BOT` enum value and updating related types and interfaces.

### Updates to naming conventions:

* [`src/models/enums.ts`](diffhunk://#diff-575541f3d947cb60d8bbc7fde50ee778781113b7383ecd87b87dab813713d632L7-R7): Renamed the `Role.BOT` enum value to `Role.FUNCTION` in the `Role` enum.
* [`src/models/request/message.ts`](diffhunk://#diff-355d3cb5ce23a560e39eb8230ec70ea0c1776eab3a40daa281932a099c5b33abL15-R15): Updated the `Message` type to replace `BotMessage` with `FunctionMessage`.
* [`src/models/request/message.ts`](diffhunk://#diff-355d3cb5ce23a560e39eb8230ec70ea0c1776eab3a40daa281932a099c5b33abL49-R50): Replaced the `BotMessage` interface with a new `FunctionMessage` interface, updating the `role` property to use `Role.FUNCTION`.