### PR TITLE
change name of secret

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -20,4 +20,4 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish-to-npm.yaml` file to use the correct authentication token for publishing to npm.

* Workflow authentication update:
  * Changed the `NODE_AUTH_TOKEN` environment variable from `secrets.GITHUB_TOKEN` to `secrets.NPM_TOKEN` in the `publish-to-npm` workflow to ensure proper authentication with npm. (`[.github/workflows/publish-to-npm.yamlL23-R23](diffhunk://#diff-ba8d164be0b8439ec65972dd4bb482cd3f161af8113995eb0ca17131c73fc745L23-R23)`)