### PR TITLE
gha changes

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,22 +1,18 @@
-name: Publish package to GitHub Packages
+name: Publish package to npm
 on:
   release:
     types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    # Remove the GitHub packages permissions block
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://npm.pkg.github.com'
-          # Defaults to the user or organization that owns the workflow file
-          scope: '@yilengyao'
+          registry-url: 'https://registry.npmjs.org'
+          # Remove the scope: '@yilengyao' line
       - run: npm ci
       - run: npm publish
         env:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "url": "https://github.com/yilengyao/llmclient.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   },
   "version": "0.0.1",
   "description": "A TypeScript library for LLM clients",


### PR DESCRIPTION
This pull request updates the workflow and configuration files to transition the package publishing process from GitHub Packages to npm. The changes involve modifying the workflow file to use the npm registry and updating the `package.json` file to reflect the new publishing configuration.

### Workflow updates:

* Renamed the workflow from "Publish package to GitHub Packages" to "Publish package to npm" and updated the registry URL to `https://registry.npmjs.org` in `.github/workflows/publish-to-npm.yaml`. Removed the GitHub-specific permissions and scope configuration.

### Configuration updates:

* Updated the `publishConfig` section in `package.json` to set the registry to `https://registry.npmjs.org` and added `"access": "public"` for npm publishing.